### PR TITLE
Add environment variable to set proxy bind address

### DIFF
--- a/magnum_cluster_api/proxy/manager.py
+++ b/magnum_cluster_api/proxy/manager.py
@@ -44,6 +44,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
             autoescape=jinja2.select_autoescape(),
         ).get_template("haproxy.cfg.j2")
         self.haproxy_port = os.getenv("PROXY_PORT", utils.find_free_port())
+        self.haproxy_bind = os.getenv("PROXY_BIND", "*")
         self.haproxy_pid = None
 
     def periodic_tasks(self, context, raise_on_error=False):
@@ -51,7 +52,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
 
     def _sync_haproxy(self, proxied_clusters: list):
         # Generate HAproxy config
-        config = self.template.render(port=self.haproxy_port, clusters=proxied_clusters)
+        config = self.template.render(bind=self.haproxy_bind, port=self.haproxy_port, clusters=proxied_clusters)
 
         # Skip if no change has been done
         if self.checksum == hash(config):

--- a/magnum_cluster_api/proxy/templates/haproxy.cfg.j2
+++ b/magnum_cluster_api/proxy/templates/haproxy.cfg.j2
@@ -11,7 +11,7 @@ defaults
   timeout server  10s
 
 frontend magnum
-  bind *:{{ port }}
+  bind {{ bind }}:{{ port }}
   tcp-request inspect-delay 5s
   tcp-request content accept if { req.ssl_hello_type 1 }
   use_backend %[req.ssl_sni,lower]


### PR DESCRIPTION
This patch adds the environment variable PROXY_BIND which can be optionally set to override the default that binds to "*".

Binding on all addresses may inadvertently expose the proxy service when run on a node that also has public interfaces such as a bare metal openstack infrastructure node, or a network node.